### PR TITLE
Add Jetpack Compose calculator sample

### DIFF
--- a/android-calculator/README.md
+++ b/android-calculator/README.md
@@ -1,0 +1,13 @@
+# Simple Calculator App
+
+This project demonstrates a minimal Android application written in Kotlin using Jetpack Compose. The app allows entering digits and adding them together using a `+` button.
+
+## Building
+
+Ensure you have the Android SDK and a recent version of Gradle installed. Then run:
+
+```bash
+./gradlew build
+```
+
+Due to environment restrictions, the build may require internet access to download dependencies.

--- a/android-calculator/app/build.gradle
+++ b/android-calculator/app/build.gradle
@@ -1,0 +1,43 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.example.calculator"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+        }
+    }
+
+    compileOptions {
+        sourceCompatibility = JavaVersion.VERSION_17
+        targetCompatibility = JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+    buildFeatures {
+        compose = true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.1"
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.activity:activity-compose:1.7.2")
+    implementation("androidx.compose.material3:material3:1.1.2")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.6.1")
+}

--- a/android-calculator/app/src/main/AndroidManifest.xml
+++ b/android-calculator/app/src/main/AndroidManifest.xml
@@ -1,0 +1,16 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.example.calculator">
+
+    <application
+        android:allowBackup="true"
+        android:label="Calculator"
+        android:theme="@style/Theme.Material3.DayNight.NoActionBar">
+        <activity android:name=".MainActivity">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/android-calculator/app/src/main/java/com/example/calculator/MainActivity.kt
+++ b/android-calculator/app/src/main/java/com/example/calculator/MainActivity.kt
@@ -1,0 +1,79 @@
+package com.example.calculator
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.*
+import androidx.compose.runtime.*
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+class MainActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                CalculatorApp()
+            }
+        }
+    }
+}
+
+@Composable
+fun CalculatorApp() {
+    var currentInput by remember { mutableStateOf("") }
+    var sum by remember { mutableStateOf(0) }
+
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text(text = "Sum: $sum", style = MaterialTheme.typography.headlineMedium)
+        Spacer(Modifier.height(16.dp))
+
+        Digits(onDigit = { digit ->
+            currentInput += digit
+        })
+
+        Spacer(Modifier.height(16.dp))
+
+        Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+            Button(onClick = {
+                val value = currentInput.toIntOrNull() ?: 0
+                sum += value
+                currentInput = ""
+            }, modifier = Modifier.weight(1f)) {
+                Text("+")
+            }
+            Button(onClick = { currentInput = ""; sum = 0 }, modifier = Modifier.weight(1f)) {
+                Text("Clear")
+            }
+        }
+        Spacer(Modifier.height(16.dp))
+        Text(text = "Current input: $currentInput")
+    }
+}
+
+@Composable
+fun Digits(onDigit: (String) -> Unit) {
+    val rows = listOf(
+        listOf("1", "2", "3"),
+        listOf("4", "5", "6"),
+        listOf("7", "8", "9"),
+        listOf("0")
+    )
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        for (row in rows) {
+            Row(Modifier.fillMaxWidth(), horizontalArrangement = Arrangement.spacedBy(8.dp)) {
+                for (digit in row) {
+                    Button(onClick = { onDigit(digit) }, modifier = Modifier.weight(1f)) {
+                        Text(digit)
+                    }
+                }
+                if (row.size < 3) {
+                    repeat(3 - row.size) {
+                        Spacer(Modifier.weight(1f))
+                    }
+                }
+            }
+        }
+    }
+}

--- a/android-calculator/build.gradle
+++ b/android-calculator/build.gradle
@@ -1,0 +1,17 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath("com.android.tools.build:gradle:8.1.0")
+        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.10")
+    }
+}
+
+allprojects {
+    repositories {
+        google()
+        mavenCentral()
+    }
+}

--- a/android-calculator/gradle/wrapper/gradle-wrapper.properties
+++ b/android-calculator/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,1 @@
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-all.zip

--- a/android-calculator/gradlew
+++ b/android-calculator/gradlew
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh
+
+if [ -z "$GRADLE_HOME" ]; then
+  gradle_cmd=gradle
+else
+  gradle_cmd="$GRADLE_HOME/bin/gradle"
+fi
+
+exec "$gradle_cmd" "$@"

--- a/android-calculator/gradlew.bat
+++ b/android-calculator/gradlew.bat
@@ -1,0 +1,4 @@
+@echo off
+set gradle_cmd=gradle
+if not "%GRADLE_HOME%"=="" set gradle_cmd=%GRADLE_HOME%\bin\gradle
+%gradle_cmd% %*

--- a/android-calculator/settings.gradle
+++ b/android-calculator/settings.gradle
@@ -1,0 +1,18 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+    }
+}
+
+rootProject.name = "calculator"
+include(":app")


### PR DESCRIPTION
## Summary
- initialize a basic Android project with Jetpack Compose
- implement `MainActivity` with simple digit input and `+` functionality
- add Gradle build configuration and instructions

## Testing
- `./gradlew tasks --all` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6888941d5174832189a52eb55964c2f2